### PR TITLE
Implement Async{Read,Write} from futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,18 @@ readme = "README.md"
 license = "MIT"
 edition = "2018"
 
+[features]
+default = ["tokio"]
+
 [dependencies]
-tokio = { version = "0.2", features= [] }
+tokio = { version = "0.2", features= [], optional = true }
 log = "0.4"
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
+
+[package.metadata.docs.rs]
+features = ["futures"]
+
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Documentation](https://docs.rs/async-pipe/badge.svg)](https://docs.rs/async-pipe)
 [![MIT](https://img.shields.io/crates/l/async-pipe.svg)](./LICENSE)
 
-Creates an asynchronous piped reader and writer pair using `tokio.rs`.
+Creates an asynchronous piped reader and writer pair using `tokio.rs` or
+`futures`
 
 [Docs](https://docs.rs/async-pipe)
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,9 +5,7 @@ use tokio::prelude::*;
 async fn main() {
     let (mut w, mut r) = async_pipe::pipe();
 
-    tokio::spawn(async move {
-        w.write_all(b"hello world").await.unwrap();
-    });
+    let _ = w.write_all(b"hello world").await;
 
     let mut v = Vec::new();
     r.read_to_end(&mut v).await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Creates an asynchronous piped reader and writer pair using `tokio.rs`.
+//! Creates an asynchronous piped reader and writer pair using `tokio.rs` and `futures`.
 //!
 //! # Examples
 //!
@@ -21,6 +21,11 @@
 //!
 //! tokio::runtime::Runtime::new().unwrap().block_on(run());
 //! ```
+//!
+//! # Featues
+//!
+//! * `tokio` (default) Implement `AsyncWrite` and `AsyncRead` from `tokio::io`.
+//! * `futures` Implement `AsyncWrite` and `AsyncRead` from `futures::io`
 
 use state::State;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
We implement `AsyncRead` and `AsyncWrite` from `futures::io` for `PipeReader` and `PipeWriter`, respectively. This implementation is behind a feature flag.