### PR TITLE
Close pipes when dropping them, check for closed pipe when flushing a writer

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -124,3 +124,9 @@ impl futures::io::AsyncRead for PipeReader {
         self.poll_read(cx, buf)
     }
 }
+
+impl Drop for PipeReader {
+    fn drop(&mut self) {
+        self.close().ok();
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -148,6 +148,12 @@ impl PipeWriter {
     }
 }
 
+impl Drop for PipeWriter {
+    fn drop(&mut self) {
+        self.close().ok();
+    }
+}
+
 #[cfg(feature = "tokio")]
 impl tokio::io::AsyncWrite for PipeWriter {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {


### PR DESCRIPTION
Thanks for sharing this library! This PR makes two semi-orthogonal improvements:

1. When attempting to `flush` a closed `PipeWriter`, return an error immediately. This makes `flush` consistent with `write`, and it avoids an indefinite hang that you would otherwise get when attempting to flush a closed pipe.
2. Mark a pipe as closed when either the `PipeWriter` or `PipeReader` are dropped. Previously, when one end of a pipe was dropped, any read/writes to the other end would hang indefinitely, which does not seem like it would ever be a useful behavior.

